### PR TITLE
Fix logout clearing token expiry

### DIFF
--- a/src/store/authSlice.js
+++ b/src/store/authSlice.js
@@ -38,6 +38,7 @@ const authSlice = createSlice({
       // Clear localStorage
       localStorage.removeItem("user");
       localStorage.removeItem("token");
+      localStorage.removeItem("tokenExpiry");
     },
   },
 });


### PR DESCRIPTION
## Summary
- ensure `tokenExpiry` is removed from localStorage when logging out

## Testing
- `npm run lint` *(fails: cannot find module '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685aea68ef98832e96d574aefc029dc8