### PR TITLE
Use VITE_API_URL for axios base

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,3 +30,13 @@ DevConnect is a full-featured frontend app inspired by real-world API marketplac
 npm install
 npm run dev     # frontend
 npm run server  # json-server
+```
+
+## Configuration
+
+Create a `.env` file in the project root to override the backend URL:
+
+```bash
+# defaults to http://localhost:3001 if not set
+VITE_API_URL=http://your-api-server:3001
+```

--- a/src/api/axios.js
+++ b/src/api/axios.js
@@ -1,7 +1,9 @@
 import axios from "axios";
 
+const baseURL = import.meta.env.VITE_API_URL || "http://localhost:3001";
+
 const axiosInstance = axios.create({
-  baseURL: "http://localhost:3001", // JSON Server
+  baseURL, // JSON Server
 });
 
 export default axiosInstance;


### PR DESCRIPTION
## Summary
- pull the backend url from `import.meta.env.VITE_API_URL`
- document the new `.env` variable in the README

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685aead7a6d4832e9fb0674012023370