### PR TITLE
Fix README code block

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,3 +30,4 @@ DevConnect is a full-featured frontend app inspired by real-world API marketplac
 npm install
 npm run dev     # frontend
 npm run server  # json-server
+```


### PR DESCRIPTION
## Summary
- close the Getting Started code block in README

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685aeb99dfa8832e8d8e5c0f1070217b