### PR TITLE
Fix README formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,6 @@ npm run dev     # frontend
 npm run server  # json-server
 ```
 
-=======
 
 ## Configuration
 


### PR DESCRIPTION
## Summary
- fix README formatting by removing leftover merge line

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685af1087058832e9535de3077c2434b