### PR TITLE
Add dark mode toggle with persistence

### DIFF
--- a/src/components/DashboardLayout.jsx
+++ b/src/components/DashboardLayout.jsx
@@ -8,7 +8,7 @@ export default function DashboardLayout({ children }) {
   return (
     <div className="min-h-screen flex flex-col md:flex-row">
       {/* Mobile header with toggle */}
-      <div className="flex items-center justify-between px-4 py-3 bg-white shadow md:hidden">
+      <div className="flex items-center justify-between px-4 py-3 bg-white dark:bg-gray-800 shadow md:hidden">
         <Link to="/" className="text-lg font-bold text-blue-600">
           DevConnect
         </Link>
@@ -25,7 +25,7 @@ export default function DashboardLayout({ children }) {
       <aside
         className={`${
           sidebarOpen ? "block" : "hidden"
-        } md:block w-full md:w-64 bg-white shadow md:h-auto h-screen z-50 absolute md:relative`}
+        } md:block w-full md:w-64 bg-white dark:bg-gray-800 shadow md:h-auto h-screen z-50 absolute md:relative`}
       >
         <div className="p-6 font-bold text-blue-600 border-b text-lg md:block hidden">
           DevConnect
@@ -41,7 +41,7 @@ export default function DashboardLayout({ children }) {
       </aside>
 
       {/* Main content */}
-      <main className="flex-1 bg-gray-50 p-6">{children}</main>
+      <main className="flex-1 bg-gray-50 dark:bg-gray-900 p-6">{children}</main>
     </div>
   );
 }

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -1,11 +1,13 @@
 import { Link, useNavigate } from "react-router-dom";
 import { useDispatch, useSelector } from "react-redux";
 import { logout } from "../store/authSlice";
+import useTheme from "../hooks/useTheme";
 
 export default function Header() {
   const { isAuthenticated, user } = useSelector((state) => state.auth);
   const dispatch = useDispatch();
   const navigate = useNavigate();
+  const [theme, setTheme] = useTheme();
 
   const handleLogout = () => {
     dispatch(logout());
@@ -15,18 +17,24 @@ export default function Header() {
   if (!isAuthenticated) return null;
 
   return (
-    <header className="bg-white shadow px-6 py-3 flex items-center justify-between">
+    <header className="bg-white dark:bg-gray-800 shadow px-6 py-3 flex items-center justify-between">
       <Link to="/" className="text-xl font-bold text-blue-600">
         DevConnect
       </Link>
 
-      <nav className="flex gap-4 text-sm">
+      <nav className="flex gap-4 text-sm items-center">
         <Link to="/api-catalogue" className="hover:underline">
           API Catalogue
         </Link>
         <Link to="/dashboard" className="hover:underline">
           Dashboard
         </Link>
+        <button
+          onClick={() => setTheme(theme === "dark" ? "light" : "dark")}
+          className="hover:underline"
+        >
+          {theme === "dark" ? "Light" : "Dark"} Mode
+        </button>
         <button onClick={handleLogout} className="text-red-600 hover:underline">
           Logout
         </button>

--- a/src/components/InviteMemberModal.jsx
+++ b/src/components/InviteMemberModal.jsx
@@ -5,7 +5,7 @@ export default function InviteMemberModal({ onClose, onInvite }) {
 
   return (
     <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
-      <div className="bg-white p-6 rounded w-full max-w-md">
+      <div className="bg-white dark:bg-gray-800 p-6 rounded w-full max-w-md">
         <h2 className="text-lg font-bold mb-4">Invite Team Member</h2>
         <input
           type="email"

--- a/src/components/UploadCertModal.jsx
+++ b/src/components/UploadCertModal.jsx
@@ -29,7 +29,7 @@ export default function UploadCertModal({ onClose, onUpload }) {
 
   return (
     <div className="fixed inset-0 bg-black bg-opacity-50 z-50 flex items-center justify-center">
-      <div className="bg-white p-6 rounded shadow w-full max-w-md">
+      <div className="bg-white dark:bg-gray-800 p-6 rounded shadow w-full max-w-md">
         <h2 className="text-xl font-bold mb-4">📥 Upload Certificate</h2>
         <div
           {...getRootProps()}
@@ -40,7 +40,7 @@ export default function UploadCertModal({ onClose, onUpload }) {
         </div>
 
         {certInfo && (
-          <div className="mt-4 text-sm bg-gray-50 p-3 rounded border">
+          <div className="mt-4 text-sm bg-gray-50 dark:bg-gray-700 p-3 rounded border">
             <p>
               <strong>Subject:</strong> {certInfo.subject}
             </p>

--- a/src/hooks/useTheme.js
+++ b/src/hooks/useTheme.js
@@ -1,0 +1,27 @@
+import { useEffect, useState } from "react";
+
+const getPreferredTheme = () => {
+  if (typeof localStorage !== "undefined" && localStorage.getItem("theme")) {
+    return localStorage.getItem("theme");
+  }
+  if (window.matchMedia("(prefers-color-scheme: dark)").matches) {
+    return "dark";
+  }
+  return "light";
+};
+
+export default function useTheme() {
+  const [theme, setTheme] = useState(getPreferredTheme);
+
+  useEffect(() => {
+    const root = document.documentElement;
+    if (theme === "dark") {
+      root.classList.add("dark");
+    } else {
+      root.classList.remove("dark");
+    }
+    localStorage.setItem("theme", theme);
+  }, [theme]);
+
+  return [theme, setTheme];
+}

--- a/src/main.css
+++ b/src/main.css
@@ -3,5 +3,5 @@
 @tailwind utilities;
 
 body {
-  @apply bg-gray-50;
+  @apply bg-gray-50 text-gray-900 dark:bg-gray-900 dark:text-gray-100;
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,4 +1,5 @@
 export default {
+  darkMode: "class",
   content: ["./index.html", "./src/**/*.{js,jsx}"],
   theme: {
     extend: {},


### PR DESCRIPTION
## Summary
- enable class-based dark mode in Tailwind
- add a custom `useTheme` hook for handling theme and saving preference
- update global styles for dark mode
- add a dark mode toggle in `Header`
- apply dark backgrounds throughout dashboard components and modals

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685af19ec044832ea843c909d1303bd4