### PR TITLE
Add ConfirmDialog component

### DIFF
--- a/src/components/ConfirmDialog.jsx
+++ b/src/components/ConfirmDialog.jsx
@@ -1,0 +1,30 @@
+import React from "react";
+
+export default function ConfirmDialog({
+  title = "Confirm",
+  message,
+  confirmText = "Confirm",
+  cancelText = "Cancel",
+  onConfirm,
+  onCancel,
+}) {
+  return (
+    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
+      <div className="bg-white p-6 rounded shadow w-full max-w-md">
+        {title && <h2 className="text-lg font-bold mb-4">{title}</h2>}
+        {message && <p className="mb-4">{message}</p>}
+        <div className="flex justify-end gap-2">
+          <button onClick={onCancel} className="text-gray-500 hover:underline">
+            {cancelText}
+          </button>
+          <button
+            onClick={onConfirm}
+            className="bg-blue-600 text-white px-4 py-2 rounded"
+          >
+            {confirmText}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -3,10 +3,12 @@ import { useSelector } from "react-redux";
 import axios from "../api/axios";
 import { Link } from "react-router-dom";
 import DashboardLayout from "../components/DashboardLayout";
+import ConfirmDialog from "../components/ConfirmDialog";
 
 export default function Dashboard() {
   const user = useSelector((state) => state.auth.user);
   const [subscriptions, setSubscriptions] = useState([]);
+  const [deleteId, setDeleteId] = useState(null);
 
   useEffect(() => {
     if (!user?.email) return;
@@ -17,21 +19,24 @@ export default function Dashboard() {
       .catch((err) => console.error("Failed to fetch subscriptions:", err));
   }, [user?.email]);
 
-  const handleDelete = async (id) => {
-    if (!confirm("Are you sure you want to remove this subscription?")) return;
+  const handleDelete = async () => {
+    if (deleteId === null) return;
     try {
-      await axios.delete(`/subscriptions/${id}`);
-      setSubscriptions((prev) => prev.filter((s) => s.id !== id));
+      await axios.delete(`/subscriptions/${deleteId}`);
+      setSubscriptions((prev) => prev.filter((s) => s.id !== deleteId));
     } catch (err) {
       console.error("Failed to delete:", err);
       alert("Failed to remove subscription.");
+    } finally {
+      setDeleteId(null);
     }
   };
 
   return (
-    <DashboardLayout>
-      <h1 className="text-2xl font-bold mb-6">👋 Welcome, {user?.name}</h1>
-      <h2 className="text-lg font-semibold mb-4">📄 Your Subscriptions</h2>
+    <>
+      <DashboardLayout>
+        <h1 className="text-2xl font-bold mb-6">👋 Welcome, {user?.name}</h1>
+        <h2 className="text-lg font-semibold mb-4">📄 Your Subscriptions</h2>
 
       {subscriptions.length === 0 ? (
         <p>You haven’t subscribed to any APIs yet.</p>
@@ -61,7 +66,7 @@ export default function Dashboard() {
                 </Link>
 
                 <button
-                  onClick={() => handleDelete(sub.id)}
+                  onClick={() => setDeleteId(sub.id)}
                   className="text-red-600 text-sm underline"
                 >
                   Remove
@@ -71,6 +76,16 @@ export default function Dashboard() {
           ))}
         </div>
       )}
-    </DashboardLayout>
+      </DashboardLayout>
+      {deleteId !== null && (
+        <ConfirmDialog
+          title="Remove Subscription"
+          message="Are you sure you want to remove this subscription?"
+          confirmText="Remove"
+          onConfirm={handleDelete}
+          onCancel={() => setDeleteId(null)}
+        />
+      )}
+    </>
   );
 }


### PR DESCRIPTION
## Summary
- add reusable `ConfirmDialog` modal component
- replace browser `confirm()` call in Dashboard with the new component

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685af1b14b74832eadc87a4eafb9b1df